### PR TITLE
Enhance ingestion workflow and API ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,113 +5,201 @@
 
 # 📘 PolicyBot – AI Policy Assistant
 
-An **AI-powered assistant** that makes company policies instantly accessible and understandable.  
-Instead of searching through 100+ page PDFs, **PolicyBot retrieves the most relevant snippets and summarizes them into clear answers** with source references.  
+PolicyBot is an **AI-powered retrieval-augmented generation (RAG) assistant** that makes long policy manuals instantly searchable. It ingests policy documents, indexes them with FAISS, retrieves the most relevant snippets, and summarizes them into clear answers—complete with supporting context so compliance teams can trust every response.
+
+---
+
+## 🧭 Table of Contents
+1. [Features](#-features)
+2. [Architecture](#-architecture)
+3. [Getting Started](#-getting-started)
+   - [Prerequisites](#prerequisites)
+   - [Clone and Install](#clone-and-install)
+   - [Set Up Your Index](#set-up-your-index)
+   - [Run the API](#run-the-api)
+   - [Query the Assistant](#query-the-assistant)
+4. [Configuration](#-configuration)
+5. [Development Workflow](#-development-workflow)
+6. [Docker Usage](#-docker-usage)
+7. [Notebooks & Demos](#-notebooks--demos)
+8. [Testing](#-testing)
+9. [Troubleshooting](#-troubleshooting)
+10. [License & Contact](#-license--contact)
 
 ---
 
 ## 🚀 Features
-- ✅ Retrieve top-K relevant policy snippets (RAG + FAISS + LangChain)  
-- ✅ Summarize into clear, exec-friendly responses (BART, Flan-T5, XSum)  
-- ✅ Always return **answer + source context** for compliance  
-- ✅ Deployable API with **FastAPI**  
-- ✅ Containerized for production with **Docker**  
-- ✅ Optional Slack / MS Teams integration  
+- ✅ Retrieve top-*k* policy snippets with **FAISS** + **LangChain**
+- ✅ Summarize answers via **Hugging Face** summarization models (defaults to `facebook/bart-large-cnn`)
+- ✅ Return both the answer and supporting context for auditability
+- ✅ Serve the assistant through a lightweight **FastAPI** service
+- ✅ Ship the entire pipeline as a **Docker** container for reproducible deployments
+- ✅ Provide example policies, notebooks, and scripts to accelerate experimentation
 
 ---
 
-## 📂 Project Structure
-```bash
+## 🧱 Architecture
+```
 policybot-ai/
 ├── src/
-│   ├── ingest.py          # Upload & index policies
-│   ├── rag_pipeline.py    # Retrieval + summarization
-│   ├── app.py             # FastAPI chatbot API
-│   └── utils.py           # Shared helpers
-├── notebooks/             # Demo notebooks
-│   ├── 01_ingest_demo.ipynb
-│   └── 02_chat_demo.ipynb
-├── data/                  # Sample policies (HR/IT/Compliance)
-├── Dockerfile             # Container build
-├── requirements.txt       # Dependencies
-└── README.md
+│   ├── ingest.py          # Build the FAISS index from raw policy text
+│   ├── rag_pipeline.py    # Retrieve relevant chunks & summarize the answer
+│   ├── app.py             # FastAPI app exposing `GET /` and `POST /ask`
+│   └── utils.py           # Shared preprocessing helpers (extend as needed)
+├── data/                  # Sample policies & generated FAISS index
+├── notebooks/             # Interactive demos for ingestion & querying
+├── requirements.txt       # Python dependencies
+└── README.md              # Project documentation
 ```
+1. **Ingestion** – `ingest.py` splits policies into overlapping chunks using `RecursiveCharacterTextSplitter`, embeds them with `sentence-transformers/all-MiniLM-L6-v2`, and stores them in a local FAISS index.
+2. **Retrieval + Generation** – `rag_pipeline.py` loads the FAISS index, retrieves the top results for a question, and summarizes the best match with a Hugging Face summarization pipeline.
+3. **Serving Layer** – `app.py` wraps the pipeline in a FastAPI service. The `/ask` endpoint accepts a form field called `query` and returns the answer payload.
 
-⚡ Quick Start (One-Click Setup)
+---
 
-```
-# Clone repository
+## 🛠 Getting Started
+
+### Prerequisites
+- Python **3.9+** (3.10 recommended)
+- `pip` for dependency management
+- Optional: Docker 20.10+ for containerized runs
+- Optional: A Hugging Face token if you plan to use gated models
+
+### Clone and Install
+```bash
 git clone https://github.com/mishuhaque/policybot-ai.git
 cd policybot-ai
 
-# Install dependencies
+# (Optional) Create a virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+pip install --upgrade pip
 pip install -r requirements.txt
-
-# Ingest company policies
-python src/ingest.py --path data/sample_policies/
-
-# Run FastAPI server
-uvicorn src.app:app --reload
-# API available at: http://127.0.0.1:8000/docs
-
-# ---- Docker Setup ----
-# Build Docker image
-docker build -t policybot-ai .
-
-# Run container
-docker run -p 8000:8000 policybot-ai
-# API available at: http://127.0.0.1:8000/docs
-
 ```
 
-📡 Example Request
+### Set Up Your Index
+By default, the repository ships with toy policies in `data/`. To build an index with your own documents you have two options:
 
+**1. Command-line ingestion**
+
+```bash
+python src/ingest.py --input /path/to/policies --output data/policy_index \
+  --chunk-size 750 --chunk-overlap 75
 ```
-curl -X POST "http://127.0.0.1:8000/query" \
--H "Content-Type: application/json" \
--d '{"question":"What is the parental leave policy?"}'
 
+* `--input` accepts either a single `.txt`/`.md` file or a directory containing multiple documents.
+* `--output` controls where the FAISS files are written (defaults to `data/policy_index`).
+* `--chunk-size`, `--chunk-overlap`, and `--embedding-model` expose the same knobs available in code.
+
+**2. Programmatic ingestion**
+
+```python
+from src.ingest import build_index
+
+policies = ["My first policy section", "My second policy section"]
+build_index(policies, save_path="data/policy_index")
 ```
 
-Example Response
+The CLI uses UTF-8 by default and will ignore empty/whitespace-only documents. If you receive a "No valid policy text provided" error, check that the source files contain readable text.
 
+### Run the API
+```bash
+uvicorn src.app:app --host 0.0.0.0 --port 8000 --reload
 ```
+Available endpoints:
+- `GET /` – health check (`{"msg": "PolicyBot API is running"}`)
+- `POST /ask` – form submission with `query="Your question"`
+
+### Query the Assistant
+The `/ask` endpoint now accepts either JSON or traditional form data.
+
+**JSON payload (recommended):**
+```bash
+curl -X POST "http://127.0.0.1:8000/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is the parental leave policy?", "top_k": 5}'
+```
+
+**Form payload (backwards compatible):**
+```bash
+curl -X POST "http://127.0.0.1:8000/ask" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "query=What is the parental leave policy?"
+```
+
+Example JSON response:
+```json
 {
-  "answer": "Employees are entitled to 12 weeks parental leave with job protection under FMLA.",
-  "source": "HR Policy, Section 5.3"
+  "query": "What is the parental leave policy?",
+  "summary": "Employees are entitled to 12 weeks parental leave with job protection under FMLA.",
+  "top_k": [
+    "HR Policy: Employees are entitled to 12 weeks parental leave.",
+    "... additional retrieved chunks ..."
+  ]
 }
-
 ```
 
+---
 
-📊 ROI Example
+## ⚙️ Configuration
+- **Index location** – Both `ingest.py` and `rag_pipeline.py` default to `../data/policy_index`. Change the `save_path` and `index_path` parameters to point to a shared storage location in production.
+- **Chunking strategy** – Tune `chunk_size` and `chunk_overlap` in `ingest.py` to match the structure of your policies.
+- **Retriever depth** – Adjust `search_kwargs={"k": 3}` to balance recall and latency.
+- **Summarizer** – Swap `facebook/bart-large-cnn` with a smaller/faster model (e.g., `sshleifer/distilbart-cnn-12-6`) if GPU resources are limited.
+- **Dangerous deserialization** – `FAISS.load_local(..., allow_dangerous_deserialization=True)` is required for LangChain ≥0.1.0. Be mindful when loading untrusted indexes.
 
-Scenario: 5,000 Employees
+---
 
-Avg. salary: $40/hour
+## 🧑‍💻 Development Workflow
+1. Update or extend `src/utils.py` with reusable cleaning utilities.
+2. Run `ingest.py` to refresh the FAISS index after adding new documents.
+3. Iterate on retrieval settings in `rag_pipeline.py` to improve answer quality.
+4. Add API routes or switch to JSON payloads in `src/app.py` as your deployment grows.
+5. Capture experiments in the notebooks to share workflows with non-engineers.
 
-6 lookups/year × 30 mins each → 15,000 hours wasted
+---
 
-Lost productivity: $600K/year
-
-✅ With PolicyBot → 80% faster lookups → $480K saved annually
-✅ At 50,000 employees → $4.8M saved/year
-
-🧪 Tests
-
-
+## 📦 Docker Usage
+Build and run the container for a fully reproducible environment:
+```bash
+docker build -t policybot-ai .
+docker run -p 8000:8000 \
+  -v $(pwd)/data:/app/data \
+  policybot-ai
 ```
+Mounting the `data/` volume ensures the container can read the FAISS index you generated on the host.
+
+---
+
+## 📓 Notebooks & Demos
+- `notebooks/01_ingest_demo.ipynb` – Walkthrough of chunking, embedding, and storing policies.
+- `notebooks/02_chat_demo.ipynb` – Interactive QA demo that mirrors the FastAPI behavior.
+Use these as playgrounds for rapid prototyping before updating the production scripts.
+
+---
+
+## ✅ Testing
+Unit tests live under `tests/` (add them as the project evolves). Run the suite with:
+```bash
 pytest tests/
-
-
 ```
+If you do not have tests yet, create regression notebooks or scripts to validate retrieval accuracy and summarization quality.
 
-📜 License
+---
 
-This project is licensed under the MIT License
-.
+## 🛠 Troubleshooting
+| Issue | Likely Cause | Fix |
+|-------|--------------|-----|
+| Hugging Face model download is slow | First-time download of BART (~1.5GB) | Pre-download the model or switch to a smaller summarizer |
+| `/ask` returns empty results | FAISS index not found or empty | Re-run `ingest.py` and ensure `index_path` points to the correct directory |
+| GPU unavailable error | Summarizer defaults to GPU when available | Force CPU inference with `pipeline(..., device=-1)` |
+| Unicode/encoding errors during ingest | Mixed encodings in source documents | Normalize text via `src/utils.py` before indexing |
 
-📬 Contact
+---
 
-👤 Author: Ahshanul Haque
-📧 Email: ahshanul.haque@student.nmt.edu
+## 📜 License & Contact
+This project is licensed under the **MIT License**.
+
+Maintainer: **Ahshanul Haque**  
+📧 `ahshanul.haque@student.nmt.edu`

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ transformers
 sentence-transformers
 faiss-cpu
 langchain
+langchain-community
 fastapi
 uvicorn
+pytest

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+"""PolicyBot source package."""
+
+__all__ = ["app", "ingest", "rag_pipeline", "utils"]

--- a/src/app.py
+++ b/src/app.py
@@ -1,17 +1,63 @@
-from fastapi import FastAPI, Form
-from rag_pipeline import query_policies
+"""FastAPI application exposing the PolicyBot retrieval pipeline."""
 
-app = FastAPI()
+from __future__ import annotations
 
-@app.get("/")
-def home():
+from typing import Optional
+
+from fastapi import Body, FastAPI, Form, HTTPException
+from pydantic import BaseModel, Field
+
+from rag_pipeline import PolicyAnswer, query_policies
+
+app = FastAPI(title="PolicyBot", description="Ask questions about policy documents.")
+
+
+class QueryRequest(BaseModel):
+    """Expected payload for POST /ask requests."""
+
+    query: str = Field(..., min_length=1, description="User question about policies")
+    top_k: int = Field(3, ge=1, le=10, description="Number of policy chunks to retrieve")
+
+
+@app.get("/", summary="Health check")
+def home() -> dict[str, str]:
+    """Simple endpoint to verify the service is running."""
+
     return {"msg": "PolicyBot API is running"}
 
-@app.post("/ask")
-async def ask_policy(query: str = Form(...)):
-    result = query_policies(query)
+
+@app.post("/ask", response_model=PolicyAnswer, summary="Retrieve and summarize policies")
+async def ask_policy(
+    payload: Optional[QueryRequest] = Body(default=None),
+    query: Optional[str] = Form(default=None),
+    top_k: int = Form(default=3),
+) -> PolicyAnswer:
+    """Answer a policy-related question using the RAG pipeline.
+
+    The endpoint accepts either a JSON body matching :class:`QueryRequest` or
+    traditional form-encoded parameters for backwards compatibility.
+    """
+
+    if payload is not None:
+        query_text = payload.query
+        top_k_value = payload.top_k
+    elif query is not None:
+        query_text = query
+        top_k_value = top_k
+    else:
+        raise HTTPException(status_code=422, detail="A 'query' parameter is required.")
+
+    try:
+        result = query_policies(query_text, top_k=top_k_value)
+    except FileNotFoundError as exc:  # pragma: no cover - depends on runtime state
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     return result
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,29 +1,156 @@
-import os
+"""Utilities for converting policy documents into a FAISS vector index."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores import FAISS
 from langchain.embeddings import HuggingFaceEmbeddings
 
-def build_index(policy_texts, save_path="../data/policy_index"):
-    # Split policies into chunks
-    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
-    docs = splitter.create_documents(policy_texts)
+from utils import clean_corpus
 
-    # Use MiniLM embeddings
-    embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+DEFAULT_INDEX_PATH = Path("../data/policy_index")
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+SUPPORTED_SUFFIXES = (".md", ".txt")
 
-    # Build FAISS index
-    db = FAISS.from_documents(docs, embeddings)
 
-    # Save locally
-    os.makedirs(save_path, exist_ok=True)
-    db.save_local(save_path)
+def build_index(
+    policy_texts: Sequence[str],
+    save_path: Path | str = DEFAULT_INDEX_PATH,
+    *,
+    chunk_size: int = 500,
+    chunk_overlap: int = 50,
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL,
+) -> Path:
+    """Create a FAISS index for the provided policy snippets.
 
-    print(f"✅ Index saved at {save_path}")
+    Parameters
+    ----------
+    policy_texts:
+        A sequence of policy strings to ingest.
+    save_path:
+        Directory where the FAISS index should be persisted.
+    chunk_size, chunk_overlap:
+        Chunking strategy supplied to :class:`RecursiveCharacterTextSplitter`.
+    embedding_model:
+        Hugging Face sentence transformer used to generate embeddings.
+
+    Returns
+    -------
+    pathlib.Path
+        The directory containing the saved FAISS index.
+    """
+
+    cleaned_policies = clean_corpus(policy_texts)
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+    documents = splitter.create_documents(cleaned_policies)
+
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model)
+    vector_store = FAISS.from_documents(documents, embeddings)
+
+    target_path = Path(save_path).expanduser().resolve()
+    target_path.mkdir(parents=True, exist_ok=True)
+    vector_store.save_local(str(target_path))
+
+    return target_path
+
+
+def load_policy_texts(path: Path) -> List[str]:
+    """Load plain-text policy files from *path*.
+
+    The loader accepts individual files or directories containing ``.txt`` or
+    ``.md`` documents. Files are read using UTF-8 encoding.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"No policy files found at {path}.")
+
+    if path.is_file():
+        if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+            raise ValueError(
+                f"Unsupported file type: {path.suffix}. Expected one of {SUPPORTED_SUFFIXES}."
+            )
+        return [path.read_text(encoding="utf-8")]
+
+    policy_texts: List[str] = []
+    for file_path in sorted(path.rglob("*")):
+        if file_path.is_file() and file_path.suffix.lower() in SUPPORTED_SUFFIXES:
+            policy_texts.append(file_path.read_text(encoding="utf-8"))
+
+    if not policy_texts:
+        raise ValueError(
+            f"No supported documents were discovered in {path}. Accepted suffixes: {SUPPORTED_SUFFIXES}."
+        )
+
+    return policy_texts
+
+
+def parse_args(arguments: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the ingestion CLI."""
+
+    parser = argparse.ArgumentParser(description="Build a FAISS index for policy documents.")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help="Path to a policy file or directory containing .txt/.md documents.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_INDEX_PATH,
+        help=f"Directory where the FAISS index will be stored (default: {DEFAULT_INDEX_PATH}).",
+    )
+    parser.add_argument("--chunk-size", type=int, default=500, help="Chunk size for the text splitter (default: 500).")
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        default=50,
+        help="Token overlap between chunks produced by the text splitter (default: 50).",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        type=str,
+        default=DEFAULT_EMBEDDING_MODEL,
+        help="Sentence transformer model used for embeddings.",
+    )
+
+    return parser.parse_args(arguments)
+
+
+def main() -> Path:
+    """Entry point for command-line usage."""
+
+    args = parse_args()
+
+    if args.input:
+        policies = load_policy_texts(args.input)
+    else:
+        policies = SAMPLE_POLICIES
+
+    index_path = build_index(
+        policies,
+        save_path=args.output,
+        chunk_size=args.chunk_size,
+        chunk_overlap=args.chunk_overlap,
+        embedding_model=args.embedding_model,
+    )
+
+    print(f"✅ Index saved at {index_path}")
+    return index_path
+
+
+SAMPLE_POLICIES = (
+    "HR Policy: Employees are entitled to 12 weeks parental leave.",
+    "IT Policy: Passwords must be updated every 90 days.",
+    "Compliance Policy: All customer data must follow GDPR regulations.",
+)
+
 
 if __name__ == "__main__":
-    sample_policies = [
-        "HR Policy: Employees are entitled to 12 weeks parental leave.",
-        "IT Policy: Passwords must be updated every 90 days.",
-        "Compliance Policy: All customer data must follow GDPR regulations."
-    ]
-    build_index(sample_policies)
+    main()

--- a/src/rag_pipeline.py
+++ b/src/rag_pipeline.py
@@ -1,29 +1,96 @@
-from langchain_community.vectorstores import FAISS
+"""Query the FAISS index and summarize the most relevant policy snippet."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import List
+
 from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
+from pydantic import BaseModel, Field
 from transformers import pipeline
 
-def query_policies(query, index_path="../data/policy_index"):
-    # Load FAISS index
-    embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-    db = FAISS.load_local(index_path, embeddings, allow_dangerous_deserialization=True)
-    retriever = db.as_retriever(search_kwargs={"k": 3})
+DEFAULT_INDEX_PATH = Path("../data/policy_index")
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_SUMMARIZER_MODEL = "facebook/bart-large-cnn"
+SUMMARY_CONFIG = {"max_length": 120, "min_length": 30, "do_sample": False}
 
-    # Retrieve docs (new API: invoke)
-    results = retriever.invoke(query)
 
-    # Summarize only the top-1 doc for precise answers
-    top_doc_text = results[0].page_content if results else "No relevant policies found."
-    summarizer = pipeline("summarization", model="facebook/bart-large-cnn")
-    summary = summarizer(top_doc_text, max_length=120, min_length=30, do_sample=False)
+class PolicyAnswer(BaseModel):
+    """Structured response returned to API clients."""
 
-    return {
-        "query": query,
-        "summary": summary[0]['summary_text'],
-        "top_k": [doc.page_content for doc in results]
-    }
+    query: str = Field(..., description="Original user query")
+    summary: str = Field(..., description="Generated summary for the top policy match")
+    top_k: List[str] = Field(default_factory=list, description="Raw policy excerpts considered for the answer")
+
+
+@lru_cache(maxsize=4)
+def _get_embeddings(model_name: str) -> HuggingFaceEmbeddings:
+    return HuggingFaceEmbeddings(model_name=model_name)
+
+
+@lru_cache(maxsize=2)
+def _get_summarizer(model_name: str):
+    return pipeline("summarization", model=model_name)
+
+
+def _load_vector_store(index_path: Path, embeddings: HuggingFaceEmbeddings) -> FAISS:
+    if not index_path.exists():
+        raise FileNotFoundError(
+            f"FAISS index not found at {index_path}. Run src/ingest.py to build it first."
+        )
+
+    return FAISS.load_local(str(index_path), embeddings, allow_dangerous_deserialization=True)
+
+
+def query_policies(
+    query: str,
+    index_path: Path | str = DEFAULT_INDEX_PATH,
+    *,
+    top_k: int = 3,
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL,
+    summarizer_model: str = DEFAULT_SUMMARIZER_MODEL,
+) -> PolicyAnswer:
+    """Retrieve and summarize policies relevant to *query*.
+
+    Parameters
+    ----------
+    query:
+        End-user question to forward to the vector store.
+    index_path:
+        Location of the FAISS index directory generated during ingestion.
+    top_k:
+        Number of documents to fetch from the retriever.
+    embedding_model:
+        Sentence transformer used during retrieval.
+    summarizer_model:
+        Hugging Face summarization model used to condense the top document.
+    """
+
+    if not query or not query.strip():
+        raise ValueError("Query must be a non-empty string.")
+    if top_k < 1:
+        raise ValueError("top_k must be greater than or equal to 1.")
+
+    embeddings = _get_embeddings(embedding_model)
+    vector_store = _load_vector_store(Path(index_path).expanduser().resolve(), embeddings)
+    retriever = vector_store.as_retriever(search_kwargs={"k": top_k})
+    documents = retriever.invoke(query)
+
+    top_documents = [doc.page_content for doc in documents]
+    if top_documents:
+        summarizer = _get_summarizer(summarizer_model)
+        summary_result = summarizer(top_documents[0], **SUMMARY_CONFIG)
+        summary_text = summary_result[0]["summary_text"].strip()
+    else:
+        summary_text = "No relevant policies found."
+
+    return PolicyAnswer(query=query, summary=summary_text, top_k=top_documents)
+
 
 if __name__ == "__main__":
     response = query_policies("What is the parental leave policy?")
-    print("Q:", response["query"])
-    print("Summary:", response["summary"])
-    print("Top-K Policies:", response["top_k"])
+    print("Q:", response.query)
+    print("Summary:", response.summary)
+    print("Top-K Policies:", response.top_k)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,69 @@
+"""Utility helpers shared across the PolicyBot codebase."""
+
+from __future__ import annotations
+
 import re
+from typing import Iterable, List
+
+__all__ = ["clean_text", "clean_corpus"]
+
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
 
 def clean_text(text: str) -> str:
-    text = text.strip()
-    text = re.sub(r"\s+", " ", text)
-    return text
+    """Normalize whitespace in *text* and strip leading/trailing space.
+
+    Parameters
+    ----------
+    text:
+        Raw text that may include inconsistent whitespace characters.
+
+    Returns
+    -------
+    str
+        A single-line string with collapsed whitespace. If the input contains
+        only whitespace characters, an empty string is returned.
+
+    Raises
+    ------
+    TypeError
+        If *text* is ``None``.
+    """
+
+    if text is None:  # pragma: no cover - defensive programming
+        raise TypeError("text must be a string")
+
+    normalized = _WHITESPACE_PATTERN.sub(" ", text).strip()
+    return normalized
+
+
+def clean_corpus(texts: Iterable[str]) -> List[str]:
+    """Clean a collection of policy snippets and drop empty entries.
+
+    Parameters
+    ----------
+    texts:
+        An iterable of raw policy strings. Items are cleaned with
+        :func:`clean_text`. Empty results are discarded.
+
+    Returns
+    -------
+    list of str
+        A list containing only non-empty, cleaned policy snippets.
+
+    Raises
+    ------
+    ValueError
+        If no valid policy text remains after cleaning.
+    """
+
+    cleaned: List[str] = []
+    for item in texts:
+        normalized = clean_text(item)
+        if normalized:
+            cleaned.append(normalized)
+
+    if not cleaned:
+        raise ValueError("No valid policy text provided.")
+
+    return cleaned

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src import utils
+
+
+def test_clean_text_strips_and_collapses_whitespace():
+    assert utils.clean_text("  hello   world\n") == "hello world"
+
+
+def test_clean_text_raises_on_none():
+    with pytest.raises(TypeError):
+        utils.clean_text(None)  # type: ignore[arg-type]
+
+
+def test_clean_corpus_drops_empty_entries():
+    cleaned = utils.clean_corpus(["  policy A  ", "\n", "policy B\t"])
+    assert cleaned == ["policy A", "policy B"]
+
+
+def test_clean_corpus_requires_non_empty():
+    with pytest.raises(ValueError):
+        utils.clean_corpus(["\n", "   "])


### PR DESCRIPTION
## Summary
- extend the ingestion script with reusable helpers, CLI options, and package initialization for easier imports
- cache embeddings and summarization in the RAG pipeline while exposing structured FastAPI responses that accept both JSON and form submissions
- update the README, dependency list, and add utility-focused pytest coverage to document and validate the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e035fda71c8321ae15f7390a48d840