### PR TITLE
feat: production-grade AWS ECS/Fargate deployment infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+data/policy_index
+notebooks/
+tests/
+*.md
+.env
+.env.*
+terraform/
+.github/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,183 @@
+name: Build, Push & Deploy to ECS
+
+on:
+  push:
+    branches:
+      - main        # → prod deploy
+      - develop     # → dev deploy
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: policybot
+
+jobs:
+  # ─────────────────────────────────────────
+  # Stage 1: Run tests before building image
+  # ─────────────────────────────────────────
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Run unit tests
+        run: pytest tests/ -v --tb=short
+
+  # ─────────────────────────────────────────
+  # Stage 2: Build Docker image & push to ECR
+  # ─────────────────────────────────────────
+  build-and-push:
+    name: Build & Push to ECR
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      image-uri: ${{ steps.build.outputs.image-uri }}
+      environment: ${{ steps.env.outputs.environment }}
+
+    permissions:
+      id-token: write   # Required for OIDC
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine target environment
+        id: env
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "environment=prod" >> $GITHUB_OUTPUT
+            echo "image-tag=prod-${{ github.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "image-tag=dev-${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-policybot-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image
+        id: build
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ steps.env.outputs.image-tag }}
+        run: |
+          IMAGE_URI="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          docker build -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+          echo "image-uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
+
+  # ─────────────────────────────────────────
+  # Stage 3: Deploy to ECS Fargate
+  # ─────────────────────────────────────────
+  deploy:
+    name: Deploy to ECS (${{ needs.build-and-push.outputs.environment }})
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: ${{ needs.build-and-push.outputs.environment }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-policybot-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set cluster and service names
+        id: names
+        run: |
+          ENV="${{ needs.build-and-push.outputs.environment }}"
+          if [[ "$ENV" == "prod" ]]; then
+            echo "cluster=policybot-cluster" >> $GITHUB_OUTPUT
+            echo "service=policybot-service" >> $GITHUB_OUTPUT
+            echo "family=policybot-task" >> $GITHUB_OUTPUT
+          else
+            echo "cluster=policybot-dev-cluster" >> $GITHUB_OUTPUT
+            echo "service=policybot-dev-service" >> $GITHUB_OUTPUT
+            echo "family=policybot-dev-task" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ steps.names.outputs.family }} \
+            --query taskDefinition \
+            > task-def.json
+
+      - name: Update image in task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-def.json
+          container-name: ${{ steps.names.outputs.family }}-app
+          image: ${{ needs.build-and-push.outputs.image-uri }}
+
+      - name: Deploy updated task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ steps.names.outputs.service }}
+          cluster: ${{ steps.names.outputs.cluster }}
+          wait-for-service-stability: true
+
+  # ─────────────────────────────────────────
+  # Stage 4: Smoke test via ALB
+  # ─────────────────────────────────────────
+  smoke-test:
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    needs: [deploy, build-and-push]
+    if: needs.build-and-push.outputs.environment == 'prod'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-policybot-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get ALB DNS
+        id: alb
+        run: |
+          DNS=$(aws elbv2 describe-load-balancers \
+            --names policybot-alb \
+            --query 'LoadBalancers[0].DNSName' \
+            --output text)
+          echo "dns=${DNS}" >> $GITHUB_OUTPUT
+
+      - name: Health check
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://${{ steps.alb.outputs.dns }}/)
+          if [[ "$STATUS" != "200" ]]; then
+            echo "Health check failed: HTTP $STATUS"
+            exit 1
+          fi
+          echo "Health check passed: HTTP $STATUS"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,326 @@
+# DEPLOYMENT.md
+
+Step-by-step guide to deploy PolicyBot to AWS ECS Fargate.
+
+---
+
+## Prerequisites
+
+### Tools
+
+Install all of these before starting:
+
+```bash
+# Terraform >= 1.5.0
+brew install terraform
+
+# AWS CLI v2
+brew install awscli
+
+# Docker 20.10+
+brew install --cask docker
+
+# GitHub CLI
+brew install gh
+```
+
+Verify:
+```bash
+terraform --version
+aws --version
+docker --version
+gh --version
+```
+
+### AWS Account
+
+1. Create an AWS account at https://aws.amazon.com if you don't have one
+2. Create an IAM user with `AdministratorAccess` (for initial setup only)
+3. Configure the CLI:
+```bash
+aws configure
+# Enter: Access Key ID, Secret Access Key, region (us-east-1), output format (json)
+```
+4. Verify access:
+```bash
+aws sts get-caller-identity
+```
+
+---
+
+## Step 1 — Bootstrap Terraform State Backend
+
+This creates the S3 bucket and DynamoDB table that Terraform uses to store and lock state. **Run once.**
+
+```bash
+./scripts/bootstrap-state-backend.sh
+```
+
+It will print something like:
+```
+Done. Update terraform/backend.tf with:
+  bucket = "policybot-terraform-state-123456789012"
+  region = "us-east-1"
+```
+
+Open `terraform/backend.tf` and replace `{account-id}` with your actual account ID:
+```hcl
+bucket = "policybot-terraform-state-123456789012"
+```
+
+---
+
+## Step 2 — Store JWT Secret in SSM Parameter Store
+
+This generates a cryptographically secure secret and stores it in AWS SSM. The ECS task reads it at startup — it is never stored in code or Docker images.
+
+```bash
+./scripts/store-secret-key.sh prod
+```
+
+It will print:
+```
+Stored secret at: /policybot/prod/secret_key
+ARN: arn:aws:ssm:us-east-1:123456789012:parameter/policybot/prod/secret_key
+```
+
+Copy the ARN. You will need it in Step 4.
+
+For the dev environment run the same command with `dev`:
+```bash
+./scripts/store-secret-key.sh dev
+```
+
+---
+
+## Step 3 — Set Up GitHub Actions OIDC
+
+This creates an IAM role that GitHub Actions assumes via OpenID Connect — no long-lived AWS keys are stored in GitHub.
+
+```bash
+./scripts/setup-github-oidc.sh mishuhaque policybot-ai
+```
+
+It will print:
+```
+Done. Add this to your GitHub repository variables:
+  AWS_ACCOUNT_ID = 123456789012
+  Role ARN: arn:aws:iam::123456789012:role/github-actions-policybot-deploy
+```
+
+Add `AWS_ACCOUNT_ID` as a GitHub repository variable:
+1. Go to your repo → **Settings** → **Variables** → **Actions**
+2. Click **New repository variable**
+3. Name: `AWS_ACCOUNT_ID`, Value: your account ID
+
+---
+
+## Step 4 — Update Terraform Variables
+
+Open `terraform/environments/prod/terraform.tfvars` and fill in your real values:
+
+```hcl
+aws_account_id     = "123456789012"                  # your AWS account ID
+ecr_image_uri      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot:prod-latest"
+ssm_secret_key_arn = "arn:aws:ssm:us-east-1:123456789012:parameter/policybot/prod/secret_key"
+certificate_arn    = ""   # leave empty for HTTP; paste ACM cert ARN here for HTTPS
+```
+
+For dev, update `terraform/environments/dev/terraform.tfvars` similarly.
+
+---
+
+## Step 5 — Provision AWS Infrastructure (Terraform)
+
+```bash
+cd terraform/environments/prod
+
+terraform init
+terraform plan -out=tfplan
+```
+
+Review the plan — it will create: VPC, subnets, NAT Gateways, ALB, ECS cluster, EFS, ECR, IAM roles, security groups, auto-scaling policies, and CloudWatch log group.
+
+Apply:
+```bash
+terraform apply tfplan
+```
+
+This takes **10–15 minutes**. When done, note the outputs:
+```
+alb_dns_name       = "policybot-alb-1234567890.us-east-1.elb.amazonaws.com"
+ecr_repository_url = "123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot"
+efs_id             = "fs-0abc1234"
+```
+
+---
+
+## Step 6 — Upload FAISS Index to EFS
+
+The app reads the FAISS index from EFS at `/mnt/efs`. You need to populate it before the first deployment.
+
+**Build the index locally:**
+```bash
+# Using sample policies (quick test)
+python src/ingest.py
+
+# Or using your own policy documents
+python src/ingest.py --input path/to/your/policy-docs/
+```
+
+**Upload to EFS** — the easiest way is a temporary EC2 instance in the same VPC:
+
+```bash
+# Launch a small EC2 in the same VPC (use the private subnet)
+# SSH into it, then:
+sudo apt-get install -y amazon-efs-utils
+sudo mkdir /mnt/efs
+sudo mount -t efs -o tls fs-0abc1234:/ /mnt/efs   # use your EFS ID
+sudo mkdir -p /mnt/efs/policy_index
+
+# Copy index files from your local machine to EC2, then to EFS
+# (from your local machine)
+scp -r data/policy_index/ ec2-user@{ec2-ip}:/tmp/
+# (on EC2)
+sudo cp -r /tmp/policy_index/* /mnt/efs/policy_index/
+```
+
+Verify the index files exist on EFS:
+```bash
+ls /mnt/efs/policy_index/
+# Should show: index.faiss  index.pkl
+```
+
+---
+
+## Step 7 — Build and Push Docker Image
+
+> **First-time note:** The Docker build pre-bakes HuggingFace models into the image. This takes **20–30 minutes** on first build due to the ~1.5GB BART model download. Subsequent builds are fast (cached layers).
+
+```bash
+ECR_URI="123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot"
+GIT_SHA=$(git rev-parse --short HEAD)
+
+# Login to ECR
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin "$ECR_URI"
+
+# Build
+docker build -t "${ECR_URI}:prod-${GIT_SHA}" .
+
+# Push
+docker push "${ECR_URI}:prod-${GIT_SHA}"
+```
+
+Update `terraform/environments/prod/terraform.tfvars` with the new image URI:
+```hcl
+ecr_image_uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot:prod-abc1234"
+```
+
+Then re-apply Terraform to update the ECS task definition:
+```bash
+cd terraform/environments/prod
+terraform apply -auto-approve
+```
+
+---
+
+## Step 8 — Verify the Deployment
+
+```bash
+ALB_DNS="policybot-alb-1234567890.us-east-1.elb.amazonaws.com"
+
+# Health check (should return 200)
+curl http://${ALB_DNS}/
+
+# Get a JWT token
+TOKEN=$(curl -s -X POST "http://${ALB_DNS}/token" \
+  -d "username=testuser" | jq -r .access_token)
+
+# Query a policy
+curl -X POST "http://${ALB_DNS}/ask" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is the parental leave policy?"}'
+```
+
+Expected response:
+```json
+{
+  "query": "What is the parental leave policy?",
+  "summary": "Employees are entitled to 12 weeks parental leave.",
+  "top_k": ["HR Policy: Employees are entitled to 12 weeks parental leave."]
+}
+```
+
+Check ECS service is running:
+```bash
+aws ecs describe-services \
+  --cluster policybot-cluster \
+  --services policybot-service \
+  --query 'services[0].{running:runningCount,desired:desiredCount,status:status}'
+```
+
+Check CloudWatch logs:
+```bash
+aws logs tail /ecs/policybot --follow
+```
+
+---
+
+## Step 9 — Enable CI/CD (Ongoing Deploys)
+
+After the first manual deploy, all future deploys happen automatically via GitHub Actions on push to `main`.
+
+**How it works:**
+1. Push code to `main`
+2. GitHub Actions runs: tests → Docker build → ECR push → ECS rolling deploy → smoke test
+3. ECS replaces old tasks with new ones (zero downtime, rolling update)
+
+**Monitor a deploy:**
+```bash
+# Watch ECS service during rollout
+aws ecs wait services-stable \
+  --cluster policybot-cluster \
+  --services policybot-service
+```
+
+---
+
+## Dev Environment
+
+For dev, use the `dev` environment which uses a single AZ and smaller compute (~$80/month):
+
+```bash
+cd terraform/environments/dev
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+Push a dev image with `dev-` prefix to trigger dev deploys from the `develop` branch.
+
+---
+
+## Estimated Monthly Cost
+
+| Component | Dev | Prod |
+|---|---|---|
+| ECS Fargate (tasks) | ~$30 | ~$230 |
+| NAT Gateway | ~$32 (1 AZ) | ~$64 (2 AZs) |
+| ALB | ~$16 | ~$20 |
+| EFS | ~$1 | ~$5 |
+| CloudWatch Logs | ~$1 | ~$5 |
+| **Total** | **~$80/mo** | **~$325/mo** |
+
+---
+
+## Teardown
+
+To destroy all AWS resources (stop billing):
+```bash
+cd terraform/environments/prod
+terraform destroy
+```
+
+> This deletes the ECS service, ALB, EFS (and the FAISS index on it), VPC, and all associated resources. The ECR images and SSM parameter are preserved — delete them manually if needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Stage 1: Builder — install deps with build tools
+FROM python:3.11-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /install
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+
+# Stage 2: Runtime — lean image, no build tools
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HF_HOME=/tmp/huggingface \
+    TRANSFORMERS_CACHE=/tmp/huggingface
+
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
+
+WORKDIR /app
+
+COPY src/ ./src/
+COPY requirements.txt .
+
+# Pre-bake embedding model to eliminate cold-start download
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+
+# Pre-bake summarizer model (~1.5GB — eliminates runtime download)
+RUN python -c "from transformers import pipeline; pipeline('summarization', model='facebook/bart-large-cnn')"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/scripts/bootstrap-state-backend.sh
+++ b/scripts/bootstrap-state-backend.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# One-time setup: create S3 bucket and DynamoDB table for Terraform state.
+# Run this ONCE before your first `terraform init`.
+set -euo pipefail
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION="${AWS_REGION:-us-east-1}"
+BUCKET="policybot-terraform-state-${ACCOUNT_ID}"
+TABLE="policybot-terraform-locks"
+
+echo "Creating S3 bucket: ${BUCKET}"
+if [[ "$REGION" == "us-east-1" ]]; then
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+else
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+    --create-bucket-configuration LocationConstraint="$REGION"
+fi
+
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption --bucket "$BUCKET" \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}
+    }]
+  }'
+
+aws s3api put-public-access-block --bucket "$BUCKET" \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+echo "Creating DynamoDB table: ${TABLE}"
+aws dynamodb create-table \
+  --table-name "$TABLE" \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region "$REGION"
+
+echo ""
+echo "Done. Update terraform/backend.tf with:"
+echo "  bucket = \"${BUCKET}\""
+echo "  region = \"${REGION}\""

--- a/scripts/setup-github-oidc.sh
+++ b/scripts/setup-github-oidc.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Create the OIDC provider and IAM role that GitHub Actions uses to deploy.
+# Usage: ./scripts/setup-github-oidc.sh <github-org-or-user> <repo-name>
+# Example: ./scripts/setup-github-oidc.sh mishuhaque policybot-ai
+set -euo pipefail
+
+GITHUB_ORG="${1:?Usage: $0 <github-org-or-user> <repo-name>}"
+REPO_NAME="${2:?Usage: $0 <github-org-or-user> <repo-name>}"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ROLE_NAME="github-actions-policybot-deploy"
+OIDC_URL="https://token.actions.githubusercontent.com"
+OIDC_THUMBPRINT="6938fd4d98bab03faadb97b34396831e3780aea1"
+
+echo "Creating OIDC provider for GitHub Actions..."
+aws iam create-open-id-connect-provider \
+  --url "$OIDC_URL" \
+  --client-id-list "sts.amazonaws.com" \
+  --thumbprint-list "$OIDC_THUMBPRINT" 2>/dev/null || echo "OIDC provider already exists"
+
+OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com"
+
+echo "Creating IAM role: ${ROLE_NAME}..."
+TRUST_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Federated": "${OIDC_ARN}"},
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub": "repo:${GITHUB_ORG}/${REPO_NAME}:*"
+      }
+    }
+  }]
+}
+EOF
+)
+
+aws iam create-role \
+  --role-name "$ROLE_NAME" \
+  --assume-role-policy-document "$TRUST_POLICY" 2>/dev/null || echo "Role already exists, updating trust policy..."
+
+# Deploy permissions: ECR push + ECS deploy
+cat > /tmp/deploy-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTaskDefinition",
+        "ecs:RegisterTaskDefinition",
+        "ecs:UpdateService",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": [
+        "arn:aws:iam::${ACCOUNT_ID}:role/policybot-task-execution-role",
+        "arn:aws:iam::${ACCOUNT_ID}:role/policybot-task-role"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["elasticloadbalancing:DescribeLoadBalancers"],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-name "policybot-deploy" \
+  --policy-document file:///tmp/deploy-policy.json
+
+echo ""
+echo "Done. Add this to your GitHub repository variables:"
+echo "  AWS_ACCOUNT_ID = ${ACCOUNT_ID}"
+echo "  Role ARN: arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"

--- a/scripts/store-secret-key.sh
+++ b/scripts/store-secret-key.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Store JWT secret key in SSM Parameter Store for a given environment.
+# Usage: ./scripts/store-secret-key.sh prod
+set -euo pipefail
+
+ENV="${1:-prod}"
+REGION="${AWS_REGION:-us-east-1}"
+PARAM_NAME="/policybot/${ENV}/secret_key"
+
+SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+
+aws ssm put-parameter \
+  --name "$PARAM_NAME" \
+  --value "$SECRET" \
+  --type "SecureString" \
+  --overwrite \
+  --region "$REGION"
+
+PARAM_ARN=$(aws ssm get-parameter \
+  --name "$PARAM_NAME" \
+  --region "$REGION" \
+  --query "Parameter.ARN" \
+  --output text)
+
+echo "Stored secret at: ${PARAM_NAME}"
+echo "ARN: ${PARAM_ARN}"
+echo ""
+echo "Add this ARN to terraform.tfvars as ssm_secret_key_arn"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    # Replace {account-id} with your AWS account ID before running terraform init
+    bucket         = "policybot-terraform-state-{account-id}"
+    key            = "policybot/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "policybot-terraform-locks"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,68 @@
+variable "aws_region" { default = "us-east-1" }
+variable "aws_account_id" { type = string }
+variable "ecr_image_uri" { type = string }
+variable "ssm_secret_key_arn" { type = string }
+
+locals {
+  project_name = "policybot-dev"
+  azs          = ["${var.aws_region}a"]
+}
+
+module "networking" {
+  source               = "../../modules/networking"
+  project_name         = local.project_name
+  vpc_cidr             = "10.1.0.0/16"
+  availability_zones   = local.azs
+  public_subnet_cidrs  = ["10.1.1.0/24"]
+  private_subnet_cidrs = ["10.1.11.0/24"]
+  single_nat_gateway   = true
+}
+
+module "security" {
+  source       = "../../modules/security"
+  project_name = local.project_name
+  vpc_id       = module.networking.vpc_id
+}
+
+module "ecr" {
+  source          = "../../modules/ecr"
+  repository_name = "policybot"
+}
+
+module "alb" {
+  source            = "../../modules/alb"
+  project_name      = local.project_name
+  vpc_id            = module.networking.vpc_id
+  public_subnet_ids = module.networking.public_subnet_ids
+  alb_sg_id         = module.security.alb_sg_id
+}
+
+module "efs" {
+  source             = "../../modules/efs"
+  project_name       = local.project_name
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_sg_id          = module.security.ecs_sg_id
+}
+
+module "ecs" {
+  source               = "../../modules/ecs"
+  project_name         = local.project_name
+  aws_region           = var.aws_region
+  aws_account_id       = var.aws_account_id
+  ecr_image_uri        = var.ecr_image_uri
+  private_subnet_ids   = module.networking.private_subnet_ids
+  ecs_sg_id            = module.security.ecs_sg_id
+  target_group_arn     = module.alb.target_group_arn
+  efs_id               = module.efs.efs_id
+  efs_access_point_id  = module.efs.access_point_id
+  ssm_secret_key_arn   = var.ssm_secret_key_arn
+  task_cpu             = 1024
+  task_memory          = 4096
+  desired_count        = 1
+  min_capacity         = 1
+  max_capacity         = 3
+}
+
+output "alb_dns_name" { value = module.alb.alb_dns_name }
+output "efs_id" { value = module.efs.efs_id }

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,0 +1,4 @@
+# Replace these values with your real AWS account details before applying
+aws_account_id     = "123456789012"
+ecr_image_uri      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot:dev-latest"
+ssm_secret_key_arn = "arn:aws:ssm:us-east-1:123456789012:parameter/policybot/dev/secret_key"

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,73 @@
+variable "aws_region" { default = "us-east-1" }
+variable "aws_account_id" { type = string }
+variable "ecr_image_uri" { type = string }
+variable "ssm_secret_key_arn" { type = string }
+variable "certificate_arn" { default = "" }
+
+locals {
+  project_name = "policybot"
+  azs          = ["${var.aws_region}a", "${var.aws_region}b"]
+}
+
+module "networking" {
+  source               = "../../modules/networking"
+  project_name         = local.project_name
+  vpc_cidr             = "10.0.0.0/16"
+  availability_zones   = local.azs
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+  single_nat_gateway   = false
+}
+
+module "security" {
+  source       = "../../modules/security"
+  project_name = local.project_name
+  vpc_id       = module.networking.vpc_id
+}
+
+module "ecr" {
+  source          = "../../modules/ecr"
+  repository_name = local.project_name
+}
+
+module "alb" {
+  source            = "../../modules/alb"
+  project_name      = local.project_name
+  vpc_id            = module.networking.vpc_id
+  public_subnet_ids = module.networking.public_subnet_ids
+  alb_sg_id         = module.security.alb_sg_id
+  certificate_arn   = var.certificate_arn
+}
+
+module "efs" {
+  source             = "../../modules/efs"
+  project_name       = local.project_name
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_sg_id          = module.security.ecs_sg_id
+}
+
+module "ecs" {
+  source               = "../../modules/ecs"
+  project_name         = local.project_name
+  aws_region           = var.aws_region
+  aws_account_id       = var.aws_account_id
+  ecr_image_uri        = var.ecr_image_uri
+  private_subnet_ids   = module.networking.private_subnet_ids
+  ecs_sg_id            = module.security.ecs_sg_id
+  target_group_arn     = module.alb.target_group_arn
+  efs_id               = module.efs.efs_id
+  efs_access_point_id  = module.efs.access_point_id
+  ssm_secret_key_arn   = var.ssm_secret_key_arn
+  task_cpu             = 2048
+  task_memory          = 8192
+  desired_count        = 2
+  min_capacity         = 2
+  max_capacity         = 6
+}
+
+output "alb_dns_name" { value = module.alb.alb_dns_name }
+output "ecr_repository_url" { value = module.ecr.repository_url }
+output "ecs_cluster_name" { value = module.ecs.cluster_name }
+output "ecs_service_name" { value = module.ecs.service_name }
+output "efs_id" { value = module.efs.efs_id }

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,5 @@
+# Replace these values with your real AWS account details before applying
+aws_account_id     = "123456789012"
+ecr_image_uri      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/policybot:prod-latest"
+ssm_secret_key_arn = "arn:aws:ssm:us-east-1:123456789012:parameter/policybot/prod/secret_key"
+certificate_arn    = ""  # Set to your ACM cert ARN to enable HTTPS

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -1,0 +1,85 @@
+variable "project_name" { type = string }
+variable "vpc_id" { type = string }
+variable "public_subnet_ids" { type = list(string) }
+variable "alb_sg_id" { type = string }
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for HTTPS listener. Leave empty to use HTTP only."
+  default     = ""
+}
+
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_sg_id]
+  subnets            = var.public_subnet_ids
+
+  tags = { Name = "${var.project_name}-alb" }
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.project_name}-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    interval            = 30
+    timeout             = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    matcher             = "200"
+  }
+
+  deregistration_delay = 30
+
+  tags = { Name = "${var.project_name}-tg" }
+}
+
+# HTTP listener: redirect to HTTPS if certificate provided, else forward directly
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  dynamic "default_action" {
+    for_each = var.certificate_arn != "" ? [1] : []
+    content {
+      type = "redirect"
+      redirect {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.certificate_arn == "" ? [1] : []
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.app.arn
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  count             = var.certificate_arn != "" ? 1 : 0
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+output "alb_dns_name" { value = aws_lb.main.dns_name }
+output "target_group_arn" { value = aws_lb_target_group.app.arn }

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,0 +1,46 @@
+variable "repository_name" { type = string }
+
+resource "aws_ecr_repository" "main" {
+  name                 = var.repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = { Name = var.repository_name }
+}
+
+resource "aws_ecr_lifecycle_policy" "main" {
+  repository = aws_ecr_repository.main.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["prod-", "dev-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+output "repository_url" { value = aws_ecr_repository.main.repository_url }
+output "repository_arn" { value = aws_ecr_repository.main.arn }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,245 @@
+variable "project_name" { type = string }
+variable "aws_region" { type = string }
+variable "aws_account_id" { type = string }
+variable "ecr_image_uri" { type = string }
+variable "private_subnet_ids" { type = list(string) }
+variable "ecs_sg_id" { type = string }
+variable "target_group_arn" { type = string }
+variable "efs_id" { type = string }
+variable "efs_access_point_id" { type = string }
+variable "ssm_secret_key_arn" { type = string }
+variable "task_cpu" { type = number }
+variable "task_memory" { type = number }
+variable "desired_count" { type = number }
+variable "min_capacity" { type = number }
+variable "max_capacity" { type = number }
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = { Name = "${var.project_name}-cluster" }
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${var.project_name}"
+  retention_in_days = 30
+  tags              = { Name = "/ecs/${var.project_name}" }
+}
+
+# Task Execution Role — ECS agent uses this to pull images and inject secrets
+resource "aws_iam_role" "task_execution" {
+  name = "${var.project_name}-task-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_managed" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "task_execution_ssm" {
+  name = "ssm-secrets"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameters", "ssm:GetParameter"]
+      Resource = [var.ssm_secret_key_arn]
+    }]
+  })
+}
+
+# Task Role — the application process uses this at runtime
+resource "aws_iam_role" "task" {
+  name = "${var.project_name}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "task_efs" {
+  name = "efs-access"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "elasticfilesystem:ClientMount",
+        "elasticfilesystem:ClientWrite",
+        "elasticfilesystem:ClientRootAccess"
+      ]
+      Resource = ["arn:aws:elasticfilesystem:${var.aws_region}:${var.aws_account_id}:file-system/${var.efs_id}"]
+    }]
+  })
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.project_name}-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  volume {
+    name = "policy-index"
+    efs_volume_configuration {
+      file_system_id          = var.efs_id
+      transit_encryption      = "ENABLED"
+      authorization_config {
+        access_point_id = var.efs_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([{
+    name      = "${var.project_name}-app"
+    image     = var.ecr_image_uri
+    essential = true
+
+    portMappings = [{
+      containerPort = 8000
+      protocol      = "tcp"
+    }]
+
+    mountPoints = [{
+      sourceVolume  = "policy-index"
+      containerPath = "/mnt/efs"
+      readOnly      = false
+    }]
+
+    environment = [
+      { name = "FAISS_INDEX_PATH", value = "/mnt/efs" },
+      { name = "HF_HOME", value = "/tmp/huggingface" }
+    ]
+
+    secrets = [{
+      name      = "SECRET_KEY"
+      valueFrom = var.ssm_secret_key_arn
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "ecs"
+      }
+    }
+
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      interval    = 30
+      timeout     = 10
+      retries     = 3
+      startPeriod = 120
+    }
+  }])
+}
+
+resource "aws_ecs_service" "app" {
+  name            = "${var.project_name}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_sg_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "${var.project_name}-app"
+    container_port   = 8000
+  }
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 120
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.task_execution_managed]
+}
+
+# Auto-scaling
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.app.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.project_name}-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = 70.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_policy" "memory" {
+  name               = "${var.project_name}-memory-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value       = 80.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+output "cluster_name" { value = aws_ecs_cluster.main.name }
+output "service_name" { value = aws_ecs_service.app.name }
+output "task_definition_arn" { value = aws_ecs_task_definition.app.arn }

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -1,0 +1,67 @@
+variable "project_name" { type = string }
+variable "vpc_id" { type = string }
+variable "private_subnet_ids" { type = list(string) }
+variable "ecs_sg_id" { type = string }
+
+resource "aws_efs_file_system" "main" {
+  encrypted = true
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  tags = { Name = "${var.project_name}-efs" }
+}
+
+resource "aws_security_group" "efs" {
+  name        = "${var.project_name}-efs-sg"
+  description = "Allow NFS from ECS tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [var.ecs_sg_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-efs-sg" }
+}
+
+resource "aws_efs_mount_target" "main" {
+  count           = length(var.private_subnet_ids)
+  file_system_id  = aws_efs_file_system.main.id
+  subnet_id       = var.private_subnet_ids[count.index]
+  security_groups = [aws_security_group.efs.id]
+}
+
+resource "aws_efs_access_point" "policy_index" {
+  file_system_id = aws_efs_file_system.main.id
+
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+
+  root_directory {
+    path = "/policy_index"
+    creation_info {
+      owner_uid   = 1000
+      owner_gid   = 1000
+      permissions = "755"
+    }
+  }
+
+  tags = { Name = "${var.project_name}-policy-index-ap" }
+}
+
+output "efs_id" { value = aws_efs_file_system.main.id }
+output "efs_arn" { value = aws_efs_file_system.main.arn }
+output "access_point_id" { value = aws_efs_access_point.policy_index.id }

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,90 @@
+variable "project_name" { type = string }
+variable "vpc_cidr" { type = string }
+variable "availability_zones" { type = list(string) }
+variable "public_subnet_cidrs" { type = list(string) }
+variable "private_subnet_cidrs" { type = list(string) }
+variable "single_nat_gateway" {
+  type    = bool
+  default = false
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.project_name}-vpc" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.project_name}-igw" }
+}
+
+resource "aws_subnet" "public" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.project_name}-public-${count.index + 1}" }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = { Name = "${var.project_name}-private-${count.index + 1}" }
+}
+
+resource "aws_eip" "nat" {
+  count  = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  domain = "vpc"
+  tags   = { Name = "${var.project_name}-nat-eip-${count.index + 1}" }
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+  tags          = { Name = "${var.project_name}-nat-${count.index + 1}" }
+  depends_on    = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+  tags = { Name = "${var.project_name}-public-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = var.single_nat_gateway ? 1 : length(var.availability_zones)
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+  tags = { Name = "${var.project_name}-private-rt-${count.index + 1}" }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = var.single_nat_gateway ? aws_route_table.private[0].id : aws_route_table.private[count.index].id
+}
+
+output "vpc_id" { value = aws_vpc.main.id }
+output "public_subnet_ids" { value = aws_subnet.public[*].id }
+output "private_subnet_ids" { value = aws_subnet.private[*].id }

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -1,0 +1,65 @@
+variable "project_name" { type = string }
+variable "vpc_id" { type = string }
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "Allow HTTP/HTTPS inbound to ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-alb-sg" }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.project_name}-ecs-sg"
+  description = "Allow inbound from ALB only on app port"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  # Outbound: ECR pulls, HuggingFace downloads, SSM, CloudWatch
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Outbound: EFS (NFS)
+  egress {
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-ecs-sg" }
+}
+
+output "alb_sg_id" { value = aws_security_group.alb.id }
+output "ecs_sg_id" { value = aws_security_group.ecs.id }


### PR DESCRIPTION
## Summary

- **Dockerfile**: Multi-stage build (builder → runtime) with pre-baked HuggingFace models (BART + sentence-transformers) to eliminate cold-start downloads
- **Terraform modules**: `networking` (VPC/subnets/IGW/NAT), `security` (ALB SG + ECS SG), `ecr`, `alb` (HTTPS-ready with ACM), `efs` (FAISS index persistent storage), `ecs` (Fargate cluster, task def, service, auto-scaling)
- **Environments**: `dev` (single AZ, 1vCPU/4GB, 1 task, ~$80/mo) and `prod` (multi-AZ, 2vCPU/8GB, 2 tasks, ~$325/mo) with separate tfvars
- **GitHub Actions**: 4-stage pipeline — test → build+push to ECR → ECS rolling deploy → ALB smoke test, using OIDC (no long-lived AWS credentials stored in GitHub)
- **Bootstrap scripts**: S3+DynamoDB state backend setup, SSM `SECRET_KEY` storage, GitHub OIDC IAM role creation

## Architecture

```
Internet → ALB (public, multi-AZ) → ECS Fargate (private subnets)
                                           ↕ EFS mount (FAISS index)
                                           ↕ SSM (JWT secret)
                                           ↕ CloudWatch Logs
```

## Test plan

- [ ] Run `scripts/bootstrap-state-backend.sh` to create S3/DynamoDB state backend
- [ ] Run `scripts/store-secret-key.sh prod` to store JWT secret in SSM
- [ ] Run `scripts/setup-github-oidc.sh mishuhaque policybot-ai` to configure GitHub OIDC
- [ ] Update `terraform/backend.tf` with real account ID
- [ ] Update `terraform/environments/prod/terraform.tfvars` with real values
- [ ] `terraform init && terraform plan` in `terraform/environments/prod/`
- [ ] `terraform apply` to provision infrastructure
- [ ] Build and push Docker image manually or via CI
- [ ] Verify `GET http://{ALB_DNS}/` returns 200
- [ ] Verify `POST /token` + `POST /ask` with JWT returns policy answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)